### PR TITLE
Change MCP path and implement request normalization

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from wikidataMCP import tools
 
 templates = Jinja2Templates(directory="templates")
 mcp = tools.mcp
-mcp_app = mcp.http_app(path="/mcp")
+mcp_app = mcp.http_app(path="/")
 
 
 app = FastAPI(

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from wikidataMCP import tools
 
 templates = Jinja2Templates(directory="templates")
 mcp = tools.mcp
-mcp_app = mcp.http_app(path="/")
+mcp_app = mcp.http_app(path="/mcp")
 
 
 app = FastAPI(
@@ -103,6 +103,15 @@ def _register_tool_routes() -> None:
             summary=summary,
             description=description,
         )(endpoint)
+
+
+@app.middleware("http")
+async def normalize_mcp_path(request: Request, call_next):
+    if request.url.path == "/mcp":
+        scope = dict(request.scope)
+        scope["path"] = "/mcp/"
+        request = Request(scope, request.receive)
+    return await call_next(request)
 
 
 @app.get("/", include_in_schema=False)


### PR DESCRIPTION
Update MCP path and add middleware to normalize requests.

this addresses issue #3 where users are having difficulties with trailing slash on the mcp endpoint.

A middleware has been added that silently redirects internally the request from /mcp to /mcp/ so that the router doesnt return a 301 response, possibly losing session ids in the meantime.